### PR TITLE
fix(clean): should set to auto value or undefined if required type is…

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -22,8 +22,8 @@ function cleanAllowedValue(value, allowedValues) {
 function cleanValue({
   path, genericPath, value, definition, parentObj, rootObj, schema, options, cleaningPath = [],
 }) {
-  if (definition.type !== 'object' && isObject(value)) {
-    return undefined;
+  if ((definition.type !== 'object' && isObject(value)) || (definition.type === 'object' && !isObject(value))) {
+    value = undefined;
   }
 
   if (options.autoConvert) {

--- a/lib/clean.spec.js
+++ b/lib/clean.spec.js
@@ -357,4 +357,21 @@ describe('clean', function () {
       }],
     });
   });
+
+  it('should clean object type', function () {
+    const scheme = new FasterSchema({
+      ob: {
+        type: Object,
+        autoValue({ value }) {
+          return value || {};
+        },
+      },
+      'ob._id': {
+        type: String,
+      },
+    });
+
+    const cleanObject = scheme.clean({ ob: 'test' });
+    expect(cleanObject).to.eql({ ob: {} });
+  });
 });


### PR DESCRIPTION
… object and another type was passed in.