### PR TITLE
defaultAutoValue should be generated when autoValue is unset

### DIFF
--- a/lib/FasterSchema.spec.js
+++ b/lib/FasterSchema.spec.js
@@ -486,6 +486,12 @@ describe('FasterSchema', function () {
       schema2 = FasterSchema.merge(schema2, ({ value: { type: String } }));
       expect(() => schema2.validate({})).to.not.throw();
     });
+
+    it('works when properties and their defaultValues are overwritten', function () {
+      let schema = new FasterSchema({ value: { type: String, defaultValue: 'foo' } });
+      schema = FasterSchema.merge(schema, { value: { defaultValue: 'bar' } });
+      expect(schema.clean({})).to.deep.equal({ value: 'bar' });
+    });
   });
   describe('extend', function () {
     it('works for plain object', function () {

--- a/lib/utils/defaultValueToAutoValue.js
+++ b/lib/utils/defaultValueToAutoValue.js
@@ -3,7 +3,10 @@ import getAutoValueFunction from './getAutoValueFunction';
 const hasOwn = Object.prototype.hasOwnProperty;
 
 export default function defaultValueToAutoValue(definition) {
-  if (hasOwn.call(definition, 'defaultValue') && !hasOwn.call(definition, 'autoValue')) {
+  const hasDefaultValue = hasOwn.call(definition, 'defaultValue');
+  const hasAutoValueFunction = hasOwn.call(definition, 'autoValue') && typeof definition.autoValue === 'function';
+
+  if (hasDefaultValue && !hasAutoValueFunction) {
     definition.autoValue = getAutoValueFunction(definition.defaultValue);
   }
   return definition;

--- a/lib/utils/defaultValueToAutoValue.spec.js
+++ b/lib/utils/defaultValueToAutoValue.spec.js
@@ -9,4 +9,13 @@ describe('defaultValueForAutoValue', function () {
     defaultValueForAutoValue(definition);
     expect(definition.autoValue({ isSet: false })).to.equal('foo');
   });
+
+  it('should set autoValue function when it has been reset', function () {
+    const definition = {
+      defaultValue: 'foo',
+      autoValue: null,
+    };
+    defaultValueForAutoValue(definition);
+    expect(definition.autoValue({ isSet: false })).to.equal('foo');
+  });
 });


### PR DESCRIPTION
I have not made the library 'aware' that the autoValue function has been generated because in the case we use it, we are intentionally merging the definition with the old autoValue function.

```
definition.schema = FasterSchema.merge(definition.schema.omit(field), {
        [field]: {
          ...def,
          type: EncryptSchema,
          encrypt: undefined,
          defaultValue: encrypt(def.defaultValue),
          autoValue: null,
        },
      });
```
Now, the function will be regenerated when autoValue is set to null/undefined at least. We could track that the autoValue function is a defaultAutoValue function but this should not happen in normal uses, e.g. when overwriting a default value. This is also tested in an additional unit test.